### PR TITLE
Reworked hijack example section

### DIFF
--- a/diffs/git+e1ea1928de2af7e5ae81196a6561f713afea7d27_to_draft4.diff
+++ b/diffs/git+e1ea1928de2af7e5ae81196a6561f713afea7d27_to_draft4.diff
@@ -1,0 +1,178 @@
+diff --git a/maxlen.xml b/maxlen.xml
+index c4b6784..59b1123 100644
+--- a/maxlen.xml
++++ b/maxlen.xml
+@@ -9,7 +9,7 @@
+ <?rfc comments="yes"?>
+ <?rfc inline="yes"?>
+ 
+-<rfc category="bcp" docName="draft-ietf-sidrops-rpkimaxlen-03" ipr="trust200902">
++<rfc category="bcp" docName="draft-ietf-sidrops-rpkimaxlen-04" ipr="trust200902">
+     <front>
+         <title abbrev="RPKI maxLength">The Use of Maxlength in the RPKI</title>
+ 
+@@ -77,7 +77,7 @@
+                     <code>8001</code>
+                     <country>South Africa</country>
+                 </postal>
+-                <email>benm@workonline.africa</email>
++                <email>benm@workonline.co.za</email>
+             </address>
+         </author>
+ 
+@@ -91,7 +91,7 @@
+         <abstract>
+ 
+             <t>
+-                This document recommends ways to reduce forged-origin hijack attack surface by prudently limiting the set of IP prefixes that are included in a Route Origin Authorization (ROA). One recommendation is to avoid using the maxLength attribute in ROAs except in some specific cases. The recommendations complement and extend those in RFC 7115. The document also discusses creation of ROAs for facilitating the use of Distributed Denial of Service (DDoS) mitigation services. Considerations related to ROAs and origin validation in the context of destination-based Remote Triggered Black Hole (RTBH) filtering are also highlighted.
++                This document recommends ways to reduce forged-origin attack surface by prudently limiting the address space that is included in Route Origin Authorizations (ROAs). One recommendation is to avoid using the maxLength attribute in ROAs except in some specific cases. The recommendations complement and extend those in RFC 7115. The document also discusses creation of ROAs for facilitating Distributed Denial of Service (DDoS) mitigation services. Considerations related to ROAs and origin validation for the case of destination-based Remote Triggered Black Hole (RTBH) filtering are also highlighted.
+                 
+             </t>
+ 
+@@ -102,8 +102,8 @@
+     <middle>
+         <section title="Introduction" anchor="intro">
+             <t>
+-                The RPKI <xref target="RFC6480"/> uses Route Origin Authorizations (ROAs) to create a cryptographically verifiable mapping from an IP prefix to a set of autonomous systems (ASes) that are authorized to originate that prefix.
+-                Each ROA contains a set of IP prefixes, and an AS number of an AS authorized originate all the IP prefixes in the set <xref target="RFC6482"/>.
++                The RPKI <xref target="RFC6480"/> uses Route Origin Authorizations (ROAs) to create a cryptographically verifiable mapping from an IP prefix to a set of autonomous systems (ASes) that are authorized to originate this prefix.
++                Each ROA contains a set of IP prefixes, and an AS number of an AS authorized to originate all the IP prefixes in the set <xref target="RFC6482"/>.
+                 The ROA is cryptographically signed by the party that holds a certificate for the set of IP prefixes.
+             </t>
+ 
+@@ -114,16 +114,16 @@
+             </t>
+             <t>
+                 However, measurements of current RPKI deployments have found that use of the maxLength in ROAs tends to lead to security problems.
+-                Specifically, as of June 2017, 84% of the prefixes specified in ROAs that use the maxLength attribute, are vulnerable to a forged-origin subprefix hijack <xref target="HARMFUL" />.
+-                The forged-origin prefix or subprefix hijack involves inserting a legitimate AS (as specified in a covering ROA) as the origin AS in the AS_PATH, and can be launched against any IP prefix/subprefix that has a ROA. Consider a prefix/subprefix that has a ROA but is unused, i.e., not announced in BGP by a legitimate AS. A forged-origin hijack involving such a prefix/subprefix can propagate widely throughout the Internet. On the other hand, if the prefix/subprefix were announced by the legitimate AS, then the propagation of the forged-origin hijack is somewhat limited because of its increased AS_PATH length relative to the legitimate announcement. Of course, forged-origin hijacks are harmful in both cases but the extent of harm is greater for unannounced prefixes.
++                Specifically, measurements have shown that 84% of the prefixes specified in ROAs that use the maxLength attribute, are vulnerable to a forged-origin subprefix hijack <xref target="HARMFUL" />.
++                The forged-origin prefix or subprefix hijack involves inserting the legitimate AS (as specified in the ROA) as the origin AS, and can be launched against any IP prefix/subprefix that has a ROA. Consider a prefix/subprefix that has a ROA but is unused, i.e., not announced in BGP by a legitimate AS. A forged-origin hijack involving such a prefix/subprefix can propagate widely throughout the Internet. On the other hand, if the prefix/subprefix were announced by the legitimate AS, then the propagation of the forged-origin hijack is somewhat limited because of its increased path length relative to the legitimate announcement. Of course, forged-origin hijacks are harmful in both cases but the extent of harm is greater for unannounced prefixes.          
+                 
+             </t>
+ 
+             <t>
+-                For this reason, this document recommends that, whenever possible, operators SHOULD use "minimal ROAs" that authorize only those IP prefixes that are actually originated in BGP, and no other prefixes. Further, it recommends ways to reduce forged-origin attack surface by prudently limiting the address space that is included in Route Origin Authorizations (ROAs). One recommendation is to avoid using the maxLength attribute in ROAs except in some specific cases. The recommendations complement and extend those in <xref target="RFC7115"/>. The document also discusses creation of ROAs for facilitating the use of Distributed Denial of Service (DDoS) mitigation services. Considerations related to ROAs and origin validation in the context of destination-based Remote Triggered Black Hole (RTBH) filtering are also highlighted.
+-            </t>
+-            <t>
+-                One ideal place to implement the ROA related recommendations is in the user interfaces for configuring ROAs. Thus, this document further recommends that designers and/or providers of such user interfaces SHOULD provide warnings to draw the user's attention to the risks of using the maxLength attribute.
++                For this reason, this document recommends that, whenever possible, operators SHOULD use "minimal ROAs" that include only those IP prefixes that are actually originated in BGP, and no other prefixes. Further, it recommends ways to reduce forged-origin attack surface by prudently limiting the address space that is included in Route Origin Authorizations (ROAs). One recommendation is to avoid using the maxLength attribute in ROAs except in some specific cases. The recommendations complement and extend those in <xref target="RFC7115"/>. The document also discusses creation of ROAs for facilitating Distributed Denial of Service (DDoS) mitigation services. Considerations related to ROAs and origin validation for the case of destination-based Remote Triggered Black Hole (RTBH) filtering are also highlighted.
++</t>
++<t>
++One ideal place to implement the ROA related recommendations is in the user interfaces for configuring ROAs. Thus, this document further recommends that designers and/or providers of such user interfaces SHOULD provide warnings to draw the user's attention to the risks of using the maxLength attribute.
+             </t>
+ <!--
+             <t>
+@@ -174,7 +174,6 @@
+ 
+             <t>
+                 A detailed description and discussion of forged-origin subprefix hijack are presented here, especially considering the case when the subprefix is not announced in BGP. The forged-origin subprefix hijack is relevant to a scenario in which (1) the RPKI <xref target="RFC6480"/> is deployed, and (2) routers use RPKI origin validation to drop invalid routes <xref target="RFC6811" />, but (3) BGPsec <xref target="RFC8205"/> (or any similar method to validate the truthfulness of the BGP AS_PATH attribute) is not deployed.
+-                Note that this set of assumptions accurately describes a substantial, and growing, number of large Internet networks at the time writing.
+             </t>
+ 
+             <t>
+@@ -188,7 +187,7 @@
+                 That is, the ROA should be
+                 <list>
+                     <t>
+-                        ROA:(192.168.0.0/16,192.168.225.0/24, AS 64496)
++                        ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
+                     </t>
+                 </list>
+                 This ROA is "minimal" because it includes only those IP prefixes that AS 64496 originates in BGP, but no other IP prefixes <xref target="RFC6907" />.
+@@ -261,7 +260,7 @@
+             </t>
+ 
+             <t>
+-                In summary, a forged-origin subprefix hijack has the same impact as a regular subprefix hijack, despite the increased AS_PATH length of the illegitimate route.
++                In summary, a forged-origin subprefix hijack has the same impact as a regular subprefix hijack.
+                 A forged-origin *subprefix* hijack is also more damaging than forged-origin *prefix* hijack.
+             </t>
+ 
+@@ -270,7 +269,7 @@
+         <section title="Measurements of Today's RPKI">
+ 
+             <t>
+-                Network measurements from June 1, 2017 show that 12% of the IP prefixes authorized in ROAs have a maxLength longer than their prefix length.
++                Network measurements have shown that 12% of the IP prefixes authorized in ROAs have a maxLength longer than their prefix length.
+                 The vast majority of these (84%) are vulnerable to forged-origin subprefix hijacks. These subprefixes are not announced in BGP by the legitimate AS. Even large providers are vulnerable to these attacks.
+                 See <xref target="GSG17"/> for details.
+             </t>
+@@ -325,7 +324,7 @@
+ 
+                 <t>
+                     First, suppose the RPKI only had the minimal ROA for AS 64496, as described in <xref target="hijack"/>.
+-                    But, if there is no ROA authorizing AS 64500 to announce the /22 prefix, then the DDoS mitigation (and traffic scrubbing) scheme would not work.
++                    But if there is no ROA authorizing AS 64500 to announce the /22 prefix, then the DDoS mitigation (and traffic scrubbing) scheme would not work.
+                     That is, if AS 64500 originates the /22 prefix in BGP during DDoS attacks, the announcement would be invalid <xref target="RFC6811" />.
+                 </t>
+ 
+@@ -333,14 +332,14 @@
+                     Therefore, the RPKI should have two ROAs: one for AS 64496 and one for AS 64500.
+                     <list>
+                         <t>
+-                            ROA:(192.168.0.0/16,192.168.225.0/24, AS 64496)
++                            ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
+                         </t>
+                         <t>
+                             ROA:(192.168.0.0/22, AS 64500)
+                         </t>
+                     </list>
+                     Neither ROA uses the maxLength attribute.
+-                    But, the second ROA is not "minimal" because it contains a /22 prefix that is not originated by anyone in BGP during normal operations.
++                    But the second ROA is not "minimal" because it contains a /22 prefix that is not originated by anyone in BGP during normal operations.
+                     The /22 prefix is only originated by AS 64500 as part of its DDoS mitigation service during a DDoS attack.
+                 </t>
+ 
+@@ -357,7 +356,7 @@
+                     To allow for this, the RPKI should have two ROAs: one for AS 64496 and one for AS 64500.
+                     <list>
+                         <t>
+-                            ROA:(192.168.0.0/16,192.168.225.0/24, AS 64496)
++                            ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
+                         </t>
+                         <t>
+                             ROA:(192.168.0.0/22-24, AS 64500)
+@@ -391,18 +390,18 @@
+     <section title="ROAs and Origin Validation for RTBH Filtering Scenario" anchor="rtbh">
+         <t>
+             Considerations related to ROAs and origin validation <xref target="RFC6811"/> for the case of destination-based Remote Triggered Black Hole (RTBH) filtering are addressed here.
+-            In RTBH, highly specific prefixes (greater than /24 in IPv4 and greater than /48 in IPv6; possibly even /32 (IPv4) and /128 (IPv6)) are announced in BGP.
++            In RTBH filtering, highly specific prefixes (greater than /24 in IPv4 and greater than /48 in IPv6; possibly even /32 (IPv4) and /128 (IPv6)) are announced in BGP.
+             These announcements are tagged with a BLACKHOLE Community <xref target="RFC7999"/>.
+             It is obviously not desirable to use large maxlength or include any such highly specific prefixes in the ROAs to accommodate destination-based RTBH filtering.
+             Therefore, operators SHOULD accommodate this scenario by accepting BGP announcements tagged with BLACKHOLE Community only if the following conditions are met:
+-                (1) the announcement is received on a BGP session on which there is agreement to honor BLACKHOLE Community, and
+-                (2) the prefix in the announcement is covered by a ROA that has an AS number matching with the AS number of the peer on that BGP session.
++                (1) the announcement is received on a BGP session on which there is agreement to accept BLACKHOLE Community, and
++                (2) the origin AS number in the announcement matches the neighbor (customer) AS number associated with the BGP session, and (3) the prefix in the announcement is subsumed by a less-specific prefix that the neighbor (customer) AS is authorized to announce per RPKI/ROA. Additional details can be found in Section 5.5 in [NIST-800-189].
+         </t>
+     </section>
+ 
+         <section anchor="Acknowledgments" title="Acknowledgments">
+             <t>
+-                The authors would like to thank the following people for their review and contributions to this document: Omar Sagga (Boston University) and Aris Lambrianidis (AMS-IX).
++                The authors would like to thank the following people for their review and contributions to this document: Omar Sagga (Boston University) and Aris Lambrianidis (AMS-IX). Thanks are also due to Matthias Waehlisch (Free University of Berlin) for comments and suggestions.
+             </t>
+         </section>
+ 
+@@ -480,6 +479,19 @@
+             <!-- <seriesInfo name="in" value="NDSS 2017" /> -->
+         </reference>
+ 
++        <reference anchor="NIST-800-189" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-189.pdf">
++            
++            <front>
++                <title>Resilient Interdomain Traffic Exchange: BGP Security and DDoS Mitigation</title>
++                <author initials="K." surname="Sriram"><organization /></author>
++                <author initials="D." surname="Montgomery"><organization /></author>
++               
++                <date year="December 2019" />
++            </front>
++            <seriesInfo name="NIST Special Publication," value="NIST SP 800-189" />
++        </reference>
++
++
+ 
+ 
+         <?rfc include="reference.RFC.6907.xml"?>

--- a/maxlen.xml
+++ b/maxlen.xml
@@ -9,7 +9,7 @@
 <?rfc comments="yes"?>
 <?rfc inline="yes"?>
 
-<rfc category="bcp" docName="draft-ietf-sidrops-rpkimaxlen-03" ipr="trust200902">
+<rfc category="bcp" docName="draft-ietf-sidrops-rpkimaxlen-05" ipr="trust200902">
     <front>
         <title abbrev="RPKI maxLength">The Use of Maxlength in the RPKI</title>
 
@@ -103,7 +103,7 @@
         <section title="Introduction" anchor="intro">
             <t>
                 The RPKI <xref target="RFC6480"/> uses Route Origin Authorizations (ROAs) to create a cryptographically verifiable mapping from an IP prefix to a set of autonomous systems (ASes) that are authorized to originate that prefix.
-                Each ROA contains a set of IP prefixes, and an AS number of an AS authorized originate all the IP prefixes in the set <xref target="RFC6482"/>.
+                Each ROA contains a set of IP prefixes, and an AS number of an AS authorized to originate all the IP prefixes in the set <xref target="RFC6482"/>.
                 The ROA is cryptographically signed by the party that holds a certificate for the set of IP prefixes.
             </t>
 
@@ -114,8 +114,8 @@
             </t>
             <t>
                 However, measurements of current RPKI deployments have found that use of the maxLength in ROAs tends to lead to security problems.
-                Specifically, as of June 2017, 84% of the prefixes specified in ROAs that use the maxLength attribute, are vulnerable to a forged-origin subprefix hijack <xref target="HARMFUL" />.
-                The forged-origin prefix or subprefix hijack involves inserting a legitimate AS (as specified in a covering ROA) as the origin AS in the AS_PATH, and can be launched against any IP prefix/subprefix that has a ROA. Consider a prefix/subprefix that has a ROA but is unused, i.e., not announced in BGP by a legitimate AS. A forged-origin hijack involving such a prefix/subprefix can propagate widely throughout the Internet. On the other hand, if the prefix/subprefix were announced by the legitimate AS, then the propagation of the forged-origin hijack is somewhat limited because of its increased AS_PATH length relative to the legitimate announcement. Of course, forged-origin hijacks are harmful in both cases but the extent of harm is greater for unannounced prefixes.
+                Specifically, measurements have shown that 84% of the prefixes specified in ROAs that use the maxLength attribute, are vulnerable to a forged-origin subprefix hijack <xref target="HARMFUL" />.
+                The forged-origin prefix or subprefix hijack involves inserting the legitimate AS (as specified in the ROA) as the origin AS in the AS_PATH, and can be launched against any IP prefix/subprefix that has a ROA. Consider a prefix/subprefix that has a ROA but is unused, i.e., not announced in BGP by a legitimate AS. A forged-origin hijack involving such a prefix/subprefix can propagate widely throughout the Internet. On the other hand, if the prefix/subprefix were announced by the legitimate AS, then the propagation of the forged-origin hijack is somewhat limited because of its increased AS_PATH length relative to the legitimate announcement. Of course, forged-origin hijacks are harmful in both cases but the extent of harm is greater for unannounced prefixes.
                 
             </t>
 
@@ -188,7 +188,7 @@
                 That is, the ROA should be
                 <list>
                     <t>
-                        ROA:(192.168.0.0/16,192.168.225.0/24, AS 64496)
+                        ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
                     </t>
                 </list>
                 This ROA is "minimal" because it includes only those IP prefixes that AS 64496 originates in BGP, but no other IP prefixes <xref target="RFC6907" />.
@@ -270,7 +270,7 @@
         <section title="Measurements of Today's RPKI">
 
             <t>
-                Network measurements from June 1, 2017 show that 12% of the IP prefixes authorized in ROAs have a maxLength longer than their prefix length.
+                Network measurements have shown that 12% of the IP prefixes authorized in ROAs have a maxLength longer than their prefix length.
                 The vast majority of these (84%) are vulnerable to forged-origin subprefix hijacks. These subprefixes are not announced in BGP by the legitimate AS. Even large providers are vulnerable to these attacks.
                 See <xref target="GSG17"/> for details.
             </t>
@@ -325,7 +325,7 @@
 
                 <t>
                     First, suppose the RPKI only had the minimal ROA for AS 64496, as described in <xref target="hijack"/>.
-                    But, if there is no ROA authorizing AS 64500 to announce the /22 prefix, then the DDoS mitigation (and traffic scrubbing) scheme would not work.
+                    But if there is no ROA authorizing AS 64500 to announce the /22 prefix, then the DDoS mitigation (and traffic scrubbing) scheme would not work.
                     That is, if AS 64500 originates the /22 prefix in BGP during DDoS attacks, the announcement would be invalid <xref target="RFC6811" />.
                 </t>
 
@@ -333,14 +333,14 @@
                     Therefore, the RPKI should have two ROAs: one for AS 64496 and one for AS 64500.
                     <list>
                         <t>
-                            ROA:(192.168.0.0/16,192.168.225.0/24, AS 64496)
+                            ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
                         </t>
                         <t>
                             ROA:(192.168.0.0/22, AS 64500)
                         </t>
                     </list>
                     Neither ROA uses the maxLength attribute.
-                    But, the second ROA is not "minimal" because it contains a /22 prefix that is not originated by anyone in BGP during normal operations.
+                    But the second ROA is not "minimal" because it contains a /22 prefix that is not originated by anyone in BGP during normal operations.
                     The /22 prefix is only originated by AS 64500 as part of its DDoS mitigation service during a DDoS attack.
                 </t>
 
@@ -357,7 +357,7 @@
                     To allow for this, the RPKI should have two ROAs: one for AS 64496 and one for AS 64500.
                     <list>
                         <t>
-                            ROA:(192.168.0.0/16,192.168.225.0/24, AS 64496)
+                            ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
                         </t>
                         <t>
                             ROA:(192.168.0.0/22-24, AS 64500)
@@ -391,18 +391,18 @@
     <section title="ROAs and Origin Validation for RTBH Filtering Scenario" anchor="rtbh">
         <t>
             Considerations related to ROAs and origin validation <xref target="RFC6811"/> for the case of destination-based Remote Triggered Black Hole (RTBH) filtering are addressed here.
-            In RTBH, highly specific prefixes (greater than /24 in IPv4 and greater than /48 in IPv6; possibly even /32 (IPv4) and /128 (IPv6)) are announced in BGP.
+            In RTBH filtering, highly specific prefixes (greater than /24 in IPv4 and greater than /48 in IPv6; possibly even /32 (IPv4) and /128 (IPv6)) are announced in BGP.
             These announcements are tagged with a BLACKHOLE Community <xref target="RFC7999"/>.
             It is obviously not desirable to use large maxlength or include any such highly specific prefixes in the ROAs to accommodate destination-based RTBH filtering.
             Therefore, operators SHOULD accommodate this scenario by accepting BGP announcements tagged with BLACKHOLE Community only if the following conditions are met:
-                (1) the announcement is received on a BGP session on which there is agreement to honor BLACKHOLE Community, and
-                (2) the prefix in the announcement is covered by a ROA that has an AS number matching with the AS number of the peer on that BGP session.
+                (1) the announcement is received on a BGP session on which there is agreement to accept BLACKHOLE Community, and
+                (2) the origin AS number in the announcement matches the neighbor (customer) AS number associated with the BGP session, and (3) the prefix in the announcement is subsumed by a less-specific prefix that the neighbor (customer) AS is authorized to announce per RPKI/ROA. Additional details can be found in Section 5.5 in [NIST-800-189].
         </t>
     </section>
 
         <section anchor="Acknowledgments" title="Acknowledgments">
             <t>
-                The authors would like to thank the following people for their review and contributions to this document: Omar Sagga (Boston University) and Aris Lambrianidis (AMS-IX).
+                The authors would like to thank the following people for their review and contributions to this document: Omar Sagga (Boston University) and Aris Lambrianidis (AMS-IX). Thanks are also due to Matthias Waehlisch (Free University of Berlin) for comments and suggestions.
             </t>
         </section>
 
@@ -479,6 +479,19 @@
             </front>
             <!-- <seriesInfo name="in" value="NDSS 2017" /> -->
         </reference>
+
+        <reference anchor="NIST-800-189" target="https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-189.pdf">
+            
+            <front>
+                <title>Resilient Interdomain Traffic Exchange: BGP Security and DDoS Mitigation</title>
+                <author initials="K." surname="Sriram"><organization /></author>
+                <author initials="D." surname="Montgomery"><organization /></author>
+               
+                <date year="December 2019" />
+            </front>
+            <seriesInfo name="NIST Special Publication," value="NIST SP 800-189" />
+        </reference>
+
 
 
 

--- a/maxlen.xml
+++ b/maxlen.xml
@@ -173,7 +173,19 @@
         <section title="Forged-Origin Subprefix Hijack" anchor="hijack">
 
             <t>
-                A detailed description and discussion of forged-origin subprefix hijack are presented here, especially considering the case when the subprefix is not announced in BGP. The forged-origin subprefix hijack is relevant to a scenario in which (1) the RPKI <xref target="RFC6480"/> is deployed, and (2) routers use RPKI origin validation to drop invalid routes <xref target="RFC6811" />, but (3) BGPsec <xref target="RFC8205"/> (or any similar method to validate the truthfulness of the BGP AS_PATH attribute) is not deployed.
+                A detailed description and discussion of forged-origin subprefix hijacks are presented here, especially considering the case when the subprefix is not announced in BGP.
+                The forged-origin subprefix hijack is relevant to a scenario in which:
+                <list>
+                    <t>
+                        (1) the RPKI <xref target="RFC6480"/> is deployed, and
+                    </t>
+                    <t>
+                        (2) routers use RPKI origin validation to drop invalid routes <xref target="RFC6811" />, but
+                    </t>
+                    <t>
+                        (3) BGPsec <xref target="RFC8205"/> (or any similar method to validate the truthfulness of the BGP AS_PATH attribute) is not deployed.
+                    </t>
+                </list>
                 Note that this set of assumptions accurately describes a substantial, and growing, number of large Internet networks at the time writing.
             </t>
 
@@ -185,7 +197,39 @@
                 Consider the IP prefix 192.168.0.0/16 which is allocated to an organization that also operates AS 64496.
                 In BGP, AS 64496 originates the IP prefix 192.168.0.0/16 as well as its subprefix 192.168.225.0/24.
                 Therefore, the RPKI should contain a ROA authorizing AS 64496 to originate these two IP prefixes.
-                That is, the ROA should be
+            </t>
+
+            <t>
+                Suppose, however, the organization issues and publishes a ROA including a maxLength value of 24:
+                <list>
+                    <t>
+                        ROA:(192.168.0.0/16-24, AS 64496)
+                    </t>
+                </list>
+                We refer to the above as a "loose ROA" since it authorizes AS 64496 to originate any subprefix of 192.168.0.0/16 up to and including length /24, rather than only those prefixes that are intended to be announced in BGP.
+            </t>
+
+            <t>
+                Because AS 64496 only originates two prefixes in BGP: 192.168.0.0/16 and 192.168.255.0/24, all other prefixes authorized by the "loose ROA" (for instance, 192.168.0.0/24), are vulnerable to the following forged-origin subprefix hijack <xref target="RFC7115"/> <xref target="GCHSS" />:
+                <list>
+                    <t>
+                        The  hijacker AS 64511 sends a BGP announcement "192.168.0.0/24: AS 64511, AS 64496", falsely claiming that AS 64511 is a neighbor of AS 64496 and falsely claiming that AS 64496 originates the IP prefix 192.168.0.0/24.
+                        In fact, the IP prefix 192.168.0.0/24 is not originated by AS 64496.
+                    </t>
+                    <t>
+                        The hijacker's BGP announcement is valid according to the RPKI, since the ROA (192.168.0.0/16-24, AS 64496) authorizes AS 64496 to originate BGP routes for 192.168.0.0/24.
+                    </t>
+                    <t>
+                        Because AS 64496 does not actually originate a route for 192.168.0.0/24, the hijacker's route is the *only* route to the 192.168.0.0/24.
+                        Longest-prefix-match routing ensures that the hijacker's route to the subprefix 192.168.0.0/24 is always preferred over the legitimate route to 192.168.0.0/16 originated by AS 64496.
+                    </t>
+                </list>
+                Thus, the hijacker's route propagates through the Internet, the traffic destined for IP addresses in 192.168.0.0/24 will be delivered to the hijacker.
+            </t>
+
+            <t>
+                The forged-origin *subprefix* hijack would have failed if a "minimal ROA" described below was used instead of the "loose ROA".
+                In this example, a "minimal ROA" would be:
                 <list>
                     <t>
                         ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)
@@ -195,57 +239,20 @@
             </t>
 
             <t>
-                Now suppose an attacking AS 64511 originates a BGP announcement for a subprefix 192.168.0.0/24.
-                This is a standard "subprefix hijack".
-            </t>
-
-            <t>
-                In the absence of the minimal ROA above, AS 64511 could intercept traffic for the addresses in 192.168.0.0/24.
-                This is because routers perform a longest-prefix match when deciding where to forward IP packets, and 192.168.0.0/24 originated by AS 64511 is a longer prefix than 192.168.0.0/16 originated by AS 64496.
-            </t>
-
-            <t>
-                However, the minimal ROA renders AS 64511's BGP announcement invalid, because (1) this ROA "covers" the attacker's announcement (since 192.168.0.0/24 is a subprefix of 192.168.0.0/16), and (2) there is no ROA "matching" the attacker's announcement (there is no ROA for AS 64511 and IP prefix 192.168.0.0/24) <xref target="RFC6811" />.
+                The "minimal ROA" renders AS 64511's BGP announcement invalid, because:
+                <list>
+                    <t>
+                        (1) this ROA "covers" the attacker's announcement (since 192.168.0.0/24 is a subprefix of 192.168.0.0/16), and
+                    </t>
+                    <t>
+                        (2) there is no ROA "matching" the attacker's announcement (there is no ROA for AS 64511 and IP prefix 192.168.0.0/24) <xref target="RFC6811" />.
+                    </t>
+                </list>
                 If routers ignore invalid BGP announcements, the minimal ROA above ensures that the subprefix hijack will fail.
             </t>
 
             <t>
-                Now suppose that the "minimal ROA" was replaced with a "loose ROA" that used maxLength as a shorthand for set of IP prefixes that AS 64496 is authorized to originate.
-                The "loose ROA" would be:
-                <list>
-                    <t>
-                        ROA:(192.168.0.0/16-24, AS 64496)
-                    </t>
-                </list>
-                This "loose ROA" authorizes AS 64496 to originate any subprefix of 192.168.0.0/16, up to length /24. That is, AS 64496 could originate 192.168.225.0/24 as well as all of 192.168.0.0/17, 192.168.128.0/17, ..., 192.168.255.0/24 but not 192.168.0.0/25.
-            </t>
-
-            <t>
-                However, AS 64496 only originates two prefixes in BGP: 192.168.0.0/16 and 192.168.255.0/24.
-                This means that all other prefixes authorized by the "loose ROA" (for instance, 192.168.0.0/24), are vulnerable to the following forged-origin subprefix hijack <xref target="RFC7115"/> <xref target="GCHSS" />:
-            </t>
-
-            <t>
-                <list>
-                    <t>
-                        The  hijacker AS 64511 sends a BGP announcement "192.168.0.0/24: AS 64511, AS 64496", falsely claiming that AS 64511 is a neighbor of AS 64496 and falsely claiming that AS 64496 originates the IP prefix 192.168.0.0/24.
-                        In fact, the IP prefix 192.168.0.0/24 is not originated by AS 64496.
-                    </t>
-                </list>
-            </t>
-
-            <t>
-                The hijacker's BGP announcement is valid according to the RPKI, since the ROA (192.168.0.0/16-24, AS 64496) authorizes AS 64496 to originate BGP routes for 192.168.0.0/24.
-                Because AS 64496 does not actually originate a route for 192.168.0.0/24, the hijacker's route is the *only* route to the 192.168.0.0/24.
-                Longest-prefix-match routing ensures that the hijacker's route to the subprefix 192.168.0.0/24 is always preferred over the legitimate route to 192.168.0.0/16 originated by AS 64496.
-                Thus, the hijacker's route propagates through the Internet, the traffic destined for IP addresses in 192.168.0.0/24 will be delivered to the hijacker.
-            </t>
-            <t>
-                The forged-origin *subprefix* hijack would have failed if the "minimal ROA" described above was used instead of the "loose ROA".
-                If the "minimal ROA" had been used instead, the attacker would be forced to launch a forged-origin *prefix* hijack in order to attract traffic, as follows:
-            </t>
-
-            <t>
+                Thus, if a "minimal ROA" had been used, the attacker would be forced to launch a forged-origin *prefix* hijack in order to attract traffic, as follows:
                 <list>
                     <t>
                         The  hijacker AS 64511 sends a BGP announcement "192.168.0.0/16: AS 64511, AS 64496", falsely claiming that AS 64511 is a neighbor of AS 64496.
@@ -254,9 +261,15 @@
             </t>
 
             <t>
-                This forged-origin *prefix* hijack is significantly less damaging than the forged-origin *subprefix* hijack.
-                AS 64496 legitimately originates 192.168.0.0/16 in BGP, so the hijacker AS 64511 is not presenting the *only* route to 192.168.0.0/16.
-                Moreover, the path originated by AS 64511 is one hop longer than the path originated by the legitimate origin AS 64496.
+                This forged-origin *prefix* hijack is significantly less damaging than the forged-origin *subprefix* hijack:
+                <list>
+                    <t>
+                        AS 64496 legitimately originates 192.168.0.0/16 in BGP, so the hijacker AS 64511 is not presenting the *only* route to 192.168.0.0/16.
+                    </t>
+                    <t>
+                        Moreover, the path originated by AS 64511 is one hop longer than the path originated by the legitimate origin AS 64496.
+                    </t>
+                </list>
                 As discussed in <xref target="LSG16"/>, this means that the hijacker will attract less traffic than he would have in the forged-origin *subprefix* hijack, where the hijacker presents the *only* route to the hijacked subprefix.
             </t>
 


### PR DESCRIPTION
resolves #2

Total re-work of the logical ordering of the section as proposed in #2.

Whilst the laguage is largely retained, the ordering is substantially 
altered. Thus the following may be easier to review than the PR diff:

```
3.  Forged-Origin Subprefix Hijack

   A detailed description and discussion of forged-origin subprefix
   hijacks are presented here, especially considering the case when the
   subprefix is not announced in BGP.  The forged-origin subprefix
   hijack is relevant to a scenario in which:

      (1) the RPKI [RFC6480] is deployed, and

      (2) routers use RPKI origin validation to drop invalid routes
      [RFC6811], but

      (3) BGPsec [RFC8205] (or any similar method to validate the
      truthfulness of the BGP AS_PATH attribute) is not deployed.

   Note that this set of assumptions accurately describes a substantial,
   and growing, number of large Internet networks at the time writing.

   The forged-origin subprefix hijack [RFC7115] [GCHSS] is described
   here using a running example.

   Consider the IP prefix 192.168.0.0/16 which is allocated to an
   organization that also operates AS 64496.  In BGP, AS 64496
   originates the IP prefix 192.168.0.0/16 as well as its subprefix
   192.168.225.0/24.  Therefore, the RPKI should contain a ROA
   authorizing AS 64496 to originate these two IP prefixes.

   Suppose, however, the organization issues and publishes a ROA
   including a maxLength value of 24:

      ROA:(192.168.0.0/16-24, AS 64496)

   We refer to the above as a "loose ROA" since it authorizes AS 64496
   to originate any subprefix of 192.168.0.0/16 up to and including
   length /24, rather than only those prefixes that are intended to be
   announced in BGP.

   Because AS 64496 only originates two prefixes in BGP: 192.168.0.0/16
   and 192.168.255.0/24, all other prefixes authorized by the "loose
   ROA" (for instance, 192.168.0.0/24), are vulnerable to the following
   forged-origin subprefix hijack [RFC7115] [GCHSS]:

      The hijacker AS 64511 sends a BGP announcement "192.168.0.0/24: AS
      64511, AS 64496", falsely claiming that AS 64511 is a neighbor of
      AS 64496 and falsely claiming that AS 64496 originates the IP
      prefix 192.168.0.0/24.  In fact, the IP prefix 192.168.0.0/24 is
      not originated by AS 64496.

      The hijacker's BGP announcement is valid according to the RPKI,
      since the ROA (192.168.0.0/16-24, AS 64496) authorizes AS 64496 to
      originate BGP routes for 192.168.0.0/24.

      Because AS 64496 does not actually originate a route for
      192.168.0.0/24, the hijacker's route is the *only* route to the
      192.168.0.0/24.  Longest-prefix-match routing ensures that the
      hijacker's route to the subprefix 192.168.0.0/24 is always
      preferred over the legitimate route to 192.168.0.0/16 originated
      by AS 64496.

   Thus, the hijacker's route propagates through the Internet, the
   traffic destined for IP addresses in 192.168.0.0/24 will be delivered
   to the hijacker.

   The forged-origin *subprefix* hijack would have failed if a "minimal
   ROA" described below was used instead of the "loose ROA".  In this
   example, a "minimal ROA" would be:

      ROA:(192.168.0.0/16, 192.168.225.0/24, AS 64496)

   This ROA is "minimal" because it includes only those IP prefixes that
   AS 64496 originates in BGP, but no other IP prefixes [RFC6907].

   The "minimal ROA" renders AS 64511's BGP announcement invalid,
   because:

      (1) this ROA "covers" the attacker's announcement (since
      192.168.0.0/24 is a subprefix of 192.168.0.0/16), and

      (2) there is no ROA "matching" the attacker's announcement (there
      is no ROA for AS 64511 and IP prefix 192.168.0.0/24) [RFC6811].

   If routers ignore invalid BGP announcements, the minimal ROA above
   ensures that the subprefix hijack will fail.

   Thus, if a "minimal ROA" had been used, the attacker would be forced
   to launch a forged-origin *prefix* hijack in order to attract
   traffic, as follows:

      The hijacker AS 64511 sends a BGP announcement "192.168.0.0/16: AS
      64511, AS 64496", falsely claiming that AS 64511 is a neighbor of
      AS 64496.

   This forged-origin *prefix* hijack is significantly less damaging
   than the forged-origin *subprefix* hijack:

      AS 64496 legitimately originates 192.168.0.0/16 in BGP, so the
      hijacker AS 64511 is not presenting the *only* route to
      192.168.0.0/16.

      Moreover, the path originated by AS 64511 is one hop longer than
      the path originated by the legitimate origin AS 64496.

   As discussed in [LSG16], this means that the hijacker will attract
   less traffic than he would have in the forged-origin *subprefix*
   hijack, where the hijacker presents the *only* route to the hijacked
   subprefix.

   In summary, a forged-origin subprefix hijack has the same impact as a
   regular subprefix hijack, despite the increased AS_PATH length of the
   illegitimate route.  A forged-origin *subprefix* hijack is also more
   damaging than forged-origin *prefix* hijack.

```