### PR TITLE
rtgdir review nits

### DIFF
--- a/maxlen.xml
+++ b/maxlen.xml
@@ -131,13 +131,13 @@
                 ROAs tends to lead to security problems.
                 In particular, measurements taken in June 2017 showed that 84% of the prefixes
                 specified in ROAs that use the maxLength attribute, were vulnerable to a
-                forged-origin subprefix hijack <xref target="HARMFUL" />.
-                The forged-origin prefix or subprefix hijack involves inserting the legitimate AS 
+                forged-origin sub-prefix hijack <xref target="HARMFUL" />.
+                The forged-origin prefix or sub-prefix hijack involves inserting the legitimate AS
                 as specified in the ROA as the origin AS in the AS_PATH, and can be launched
-                against any IP prefix/subprefix that has a ROA. Consider a prefix/subprefix that
+                against any IP prefix/sub-prefix that has a ROA. Consider a prefix/sub-prefix that
                 has a ROA but is unused, i.e., not announced in BGP by a legitimate AS. A forged
-                origin hijack involving such a prefix/subprefix can propagate widely throughout the
-                Internet. On the other hand, if the prefix/subprefix were announced by the
+                origin hijack involving such a prefix/sub-prefix can propagate widely throughout the
+                Internet. On the other hand, if the prefix/sub-prefix were announced by the
                 legitimate AS, then the propagation of the forged-origin hijack is somewhat limited
                 because of its increased AS_PATH length relative to the legitimate announcement. Of
                 course, forged-origin hijacks are harmful in both cases but the extent of harm is
@@ -202,13 +202,13 @@
 
         </section>
 
-        <section title="Forged-Origin Subprefix Hijack" anchor="hijack">
+        <section title="Forged-Origin Sub-prefix Hijack" anchor="hijack">
 
             <t>
-                A detailed description and discussion of forged-origin subprefix hijacks are
-                presented here, especially considering the case when the subprefix is not announced
+                A detailed description and discussion of forged-origin sub-prefix hijacks are
+                presented here, especially considering the case when the sub-prefix is not announced
                 in BGP.
-                The forged-origin subprefix hijack is relevant to a scenario in which:
+                The forged-origin sub-prefix hijack is relevant to a scenario in which:
                 <list>
                     <t>
                         (1) the RPKI <xref target="RFC6480"/> is deployed, and
@@ -227,14 +227,14 @@
             </t>
 
             <t>
-                The forged-origin subprefix hijack <xref target="RFC7115" />
+                The forged-origin sub-prefix hijack <xref target="RFC7115" />
                 <xref target="GCHSS" /> is described here using a running example.
             </t>
 
             <t>
                 Consider the IP prefix 192.168.0.0/16 which is allocated to an organization that
                 also operates AS 64496.
-                In BGP, AS 64496 originates the IP prefix 192.168.0.0/16 as well as its subprefix
+                In BGP, AS 64496 originates the IP prefix 192.168.0.0/16 as well as its sub-prefix
                 192.168.225.0/24.
                 Therefore, the RPKI should contain a ROA authorizing AS 64496 to originate these
                 two IP prefixes.
@@ -249,14 +249,14 @@
                     </t>
                 </list>
                 We refer to the above as a "loose ROA" since it authorizes AS 64496 to originate
-                any subprefix of 192.168.0.0/16 up to and including length /24, rather than only
+                any sub-prefix of 192.168.0.0/16 up to and including length /24, rather than only
                 those prefixes that are intended to be announced in BGP.
             </t>
 
             <t>
                 Because AS 64496 only originates two prefixes in BGP: 192.168.0.0/16 and
                 192.168.225.0/24, all other prefixes authorized by the "loose ROA" (for instance,
-                192.168.0.0/24), are vulnerable to the following forged-origin subprefix hijack
+                192.168.0.0/24), are vulnerable to the following forged-origin sub-prefix hijack
                 <xref target="RFC7115"/> <xref target="GCHSS" />:
                 <list>
                     <t>
@@ -274,7 +274,7 @@
                         Because AS 64496 does not actually originate a route for 192.168.0.0/24,
                         the hijacker's route is the only route for 192.168.0.0/24.
                         Longest-prefix-match routing ensures that the hijacker's route to the
-                        subprefix 192.168.0.0/24 is always preferred over the legitimate route to
+                        sub-prefix 192.168.0.0/24 is always preferred over the legitimate route to
                         192.168.0.0/16 originated by AS 64496.
                     </t>
                 </list>
@@ -283,7 +283,7 @@
             </t>
 
             <t>
-                The forged-origin subprefix hijack would have failed if a "minimal ROA" described
+                The forged-origin sub-prefix hijack would have failed if a "minimal ROA" described
                 below was used instead of the "loose ROA".
                 In this example, a "minimal ROA" would be:
                 <list>
@@ -300,7 +300,7 @@
                 <list>
                     <t>
                         (1) this ROA "covers" the attacker's announcement (since 192.168.0.0/24 is
-                            a subprefix of 192.168.0.0/16), and
+                            a sub-prefix of 192.168.0.0/16), and
                     </t>
                     <t>
                         (2) there is no ROA "matching" the attacker's announcement (there is no ROA
@@ -308,7 +308,7 @@
                     </t>
                 </list>
                 If routers ignore invalid BGP announcements, the minimal ROA above ensures that the
-                subprefix hijack will fail.
+                sub-prefix hijack will fail.
             </t>
 
             <t>
@@ -324,7 +324,7 @@
 
             <t>
                 This forged-origin prefix hijack is significantly less damaging than the
-                forged-origin subprefix hijack:
+                forged-origin sub-prefix hijack:
                 <list>
                     <t>
                         AS 64496 legitimately originates 192.168.0.0/16 in BGP, so the hijacker
@@ -336,14 +336,14 @@
                     </t>
                 </list>
                 As discussed in <xref target="LSG16"/>, this means that the hijacker will attract
-                less traffic than he would have in the forged-origin subprefix hijack, where
-                the hijacker presents the only route to the hijacked subprefix.
+                less traffic than he would have in the forged-origin sub-prefix hijack, where
+                the hijacker presents the only route to the hijacked sub-prefix.
             </t>
 
             <t>
-                In summary, a forged-origin subprefix hijack has the same impact as a regular
-                subprefix hijack, despite the increased AS_PATH length of the illegitimate route.
-                A forged-origin subprefix hijack is also more damaging than the forged-origin
+                In summary, a forged-origin sub-prefix hijack has the same impact as a regular
+                sub-prefix hijack, despite the increased AS_PATH length of the illegitimate route.
+                A forged-origin sub-prefix hijack is also more damaging than the forged-origin
                 prefix hijack.
             </t>
 
@@ -354,15 +354,15 @@
             <t>
                 Network measurements taken in June 2017 showed that 12% of the IP prefixes
                 authorized in ROAs have a maxLength longer than their prefix length.
-                Of these, the vast majority (84%) were non-minimal, as they included subprefixes
+                Of these, the vast majority (84%) were non-minimal, as they included sub-prefixes
                 that are not announced in BGP by the legitimate AS, and were thus vulnerable to
-                forged-origin subprefix hijacks.
+                forged-origin sub-prefix hijacks.
                 See <xref target="GSG17"/> for details.
             </t>
 
             <t>
                 These measurements suggest that operators commonly misconfigure the maxLength
-                attribute, and unwittingly open themselves up to forged-origin subprefix hijacks.
+                attribute, and unwittingly open themselves up to forged-origin sub-prefix hijacks.
                 That is, they are exposing a much larger attack surface for forged-origin hijacks
                 than necessary.
             </t>
@@ -514,7 +514,7 @@
                 <t>
                     Notice, however, that this scheme does not come without risks.
                     Namely, all IP addresses in 192.168.0.0/22 are vulnerable to a forged-origin
-                    subprefix hijack during normal operations, when the /22 prefix is not
+                    sub-prefix hijack during normal operations, when the /22 prefix is not
                     originated.
                     (The hijacker AS 64511 would send the BGP announcement "192.168.0.0/22: 
                     AS 64511, AS 64500", falsely claiming that AS 64511 is a neighbor of AS 64500
@@ -541,13 +541,13 @@
                 </t>
                 <t>
                     The second ROA uses the maxLength attribute because it is designed to
-                    explicitly enable AS 64500 to originate any /24 subprefix of 192.168.0.0/22.
+                    explicitly enable AS 64500 to originate any /24 sub-prefix of 192.168.0.0/22.
                 </t>
                 <t>
                     As before, the second ROA is not "minimal" because it contains prefixes that
                     are not originated by anyone in BGP during normal operations.
                     As before, all IP addresses in 192.168.0.0/22 are vulnerable to a forged-origin
-                    subprefix hijack during normal operations, when the /22 prefix is not
+                    sub-prefix hijack during normal operations, when the /22 prefix is not
                     originated.
                 </t>
                 <t>
@@ -555,14 +555,14 @@
                     While it permits the DDoS mitigation service at AS 64500 to originate prefix
                     192.168.0.0/24 during a DDoS attack in that space, it also makes the other
                     /24 prefixes covered by the /22 prefix (i.e., 192.168.1.0/24, 192.168.2.0/24,
-                    192.168.3.0/24) vulnerable to a forged-origin subprefix attacks.
+                    192.168.3.0/24) vulnerable to a forged-origin sub-prefix attacks.
                 </t>
             </section>
 
             <section title="Defensive De-aggregation In Response To Prefix Hijacks" anchor="deaggr">
                 <t>
                     In responding to certain classes of prefix hijack, in particular, the
-                    forged-origin subprefix hijack described above, it may be desirable for the
+                    forged-origin sub-prefix hijack described above, it may be desirable for the
                     victim to perform "defensive de-aggregation", i.e. to begin originating
                     more-specific prefixes in order to compete with the hijack routes for selection
                     as the best path in networks that are not performing RPKI-based route origin

--- a/maxlen.xml
+++ b/maxlen.xml
@@ -97,8 +97,9 @@
                 in ROAs except in some specific cases. The recommendations complement and extend
                 those in RFC 7115. The document also discusses the creation of ROAs for facilitating
                 the use of Distributed Denial of Service (DDoS) mitigation services. Considerations
-                related to ROAs and origin validation in the context of destination-based Remote
-                Triggered Black Hole (RTBH) filtering are also highlighted.
+                related to ROAs and origin validation in the context of destination-based Remotely
+                Triggered Discard Route (RTDR) (elsewhere referred to as "Remotely Triggered
+                Black Hole") filtering are also highlighted.
             </t>
 
         </abstract>
@@ -154,8 +155,9 @@
                 recommendations complement and extend those in <xref target="RFC7115"/>. The
                 document also discusses the creation of ROAs for facilitating the use of Distributed
                 Denial of Service (DDoS) mitigation services. Considerations related to ROAs and
-                origin validation in the context of destination-based Remote Triggered Black Hole 
-                (RTBH) filtering are also highlighted.
+                origin validation in the context of destination-based Remotely Triggered Discard
+                Route (RTDR) (elsewhere referred to as "Remotely Triggered Black Hole") filtering
+                are also highlighted.
             </t>
             <t>
                 One ideal place to implement the ROA related recommendations is in the user
@@ -599,22 +601,23 @@
 
     </section>
 
-    <section title="Considerations for RTBH Filtering Scenarios" anchor="rtbh">
+    <section title="Considerations for RTDR Filtering Scenarios" anchor="rtdr">
         <t>
             Considerations related to ROAs and origin validation <xref target="RFC6811"/> for the
-            case of destination-based Remote Triggered Black Hole (RTBH) filtering are addressed
-            here.
-            In RTBH filtering, highly specific prefixes (greater than /24 in IPv4 and greater than
+            case of destination-based Remotely Triggered Discard Route (RTDR) (elsewhere referred
+            to as "Remotely Triggered Black Hole") filtering are addressed here.
+            In RTDR filtering, highly specific prefixes (greater than /24 in IPv4 and greater than
             /48 in IPv6; possibly even /32 (IPv4) and /128 (IPv6)) are announced in BGP.
-            These announcements are tagged with a BLACKHOLE Community <xref target="RFC7999"/>.
+            These announcements are tagged with the Well-known BGP Community defined by
+            <xref target="RFC7999"/>.
             It is obviously not desirable to use a large maxLength or include any such highly
-            specific prefixes in the ROAs to accommodate destination-based RTBH filtering, for the
+            specific prefixes in the ROAs to accommodate destination-based RTDR filtering, for the
             reasons set out above.
         </t>
 
         <t>
             As a result, RPKI-based route origin validation <xref target="RFC6811"/> is a poor fit
-            for the validation of RTBH routes.
+            for the validation of RTDR routes.
             Specification of new procedures to address this use case through the use of the RPKI is
             outside the scope of this document.
         </t>
@@ -624,12 +627,12 @@
             <list style="symbols">
                 <t>
                     Operators SHOULD NOT create non-minimal ROAs (either by creating additional
-                    ROAs, or through the use of maxLength) for the purpose of advertising RTBH
+                    ROAs, or through the use of maxLength) for the purpose of advertising RTDR
                     routes; and
                 </t>
                 <t>
                     Operators providing a means for operators of neighboring autonomous systems to
-                    advertise RTBH routes via BGP MUST NOT make the creation of non-minimal ROAs
+                    advertise RTDR routes via BGP MUST NOT make the creation of non-minimal ROAs
                     a pre-requisite for its use.
                 </t>
             </list>

--- a/maxlen.xml
+++ b/maxlen.xml
@@ -272,7 +272,7 @@
                     </t>
                     <t>
                         Because AS 64496 does not actually originate a route for 192.168.0.0/24,
-                        the hijacker's route is the *only* route for 192.168.0.0/24.
+                        the hijacker's route is the only route for 192.168.0.0/24.
                         Longest-prefix-match routing ensures that the hijacker's route to the
                         subprefix 192.168.0.0/24 is always preferred over the legitimate route to
                         192.168.0.0/16 originated by AS 64496.
@@ -283,7 +283,7 @@
             </t>
 
             <t>
-                The forged-origin *subprefix* hijack would have failed if a "minimal ROA" described
+                The forged-origin subprefix hijack would have failed if a "minimal ROA" described
                 below was used instead of the "loose ROA".
                 In this example, a "minimal ROA" would be:
                 <list>
@@ -313,7 +313,7 @@
 
             <t>
                 Thus, if a "minimal ROA" had been used, the attacker would be forced to launch a
-                forged-origin *prefix* hijack in order to attract traffic, as follows:
+                forged-origin prefix hijack in order to attract traffic, as follows:
                 <list>
                     <t>
                         The  hijacker AS 64511 sends a BGP announcement "192.168.0.0/16: AS 64511,
@@ -323,12 +323,12 @@
             </t>
 
             <t>
-                This forged-origin *prefix* hijack is significantly less damaging than the
-                forged-origin *subprefix* hijack:
+                This forged-origin prefix hijack is significantly less damaging than the
+                forged-origin subprefix hijack:
                 <list>
                     <t>
                         AS 64496 legitimately originates 192.168.0.0/16 in BGP, so the hijacker
-                        AS 64511 is not presenting the *only* route to 192.168.0.0/16.
+                        AS 64511 is not presenting the only route to 192.168.0.0/16.
                     </t>
                     <t>
                         Moreover, the path originated by AS 64511 is one hop longer than the path
@@ -336,15 +336,15 @@
                     </t>
                 </list>
                 As discussed in <xref target="LSG16"/>, this means that the hijacker will attract
-                less traffic than he would have in the forged-origin *subprefix* hijack, where
-                the hijacker presents the *only* route to the hijacked subprefix.
+                less traffic than he would have in the forged-origin subprefix hijack, where
+                the hijacker presents the only route to the hijacked subprefix.
             </t>
 
             <t>
                 In summary, a forged-origin subprefix hijack has the same impact as a regular
                 subprefix hijack, despite the increased AS_PATH length of the illegitimate route.
-                A forged-origin *subprefix* hijack is also more damaging than the forged-origin
-                *prefix* hijack.
+                A forged-origin subprefix hijack is also more damaging than the forged-origin
+                prefix hijack.
             </t>
 
         </section>
@@ -541,7 +541,7 @@
                 </t>
                 <t>
                     The second ROA uses the maxLength attribute because it is designed to
-                    explicitly enable AS 64500 to originate *any* /24 subprefix of 192.168.0.0/22.
+                    explicitly enable AS 64500 to originate any /24 subprefix of 192.168.0.0/22.
                 </t>
                 <t>
                     As before, the second ROA is not "minimal" because it contains prefixes that
@@ -553,7 +553,7 @@
                 <t>
                     The use of maxLength in this second ROA also comes with additional risk.
                     While it permits the DDoS mitigation service at AS 64500 to originate prefix
-                    192.168.0.0/24 during a DDoS attack in that space, it also makes the  *other*
+                    192.168.0.0/24 during a DDoS attack in that space, it also makes the other
                     /24 prefixes covered by the /22 prefix (i.e., 192.168.1.0/24, 192.168.2.0/24,
                     192.168.3.0/24) vulnerable to a forged-origin subprefix attacks.
                 </t>

--- a/maxlen.xml
+++ b/maxlen.xml
@@ -129,8 +129,8 @@
             <t>
                 However, measurements of RPKI deployments have found that the use of the maxLength in
                 ROAs tends to lead to security problems.
-                In particular, measurements taken in June 2017 showed that 84% of the prefixes
-                specified in ROAs that use the maxLength attribute, were vulnerable to a
+                In particular, measurements taken in June 2017 showed that of the prefixes
+                specified in ROAs that use the maxLength attribute, 84% were vulnerable to a
                 forged-origin sub-prefix hijack <xref target="HARMFUL" />.
                 The forged-origin prefix or sub-prefix hijack involves inserting the legitimate AS
                 as specified in the ROA as the origin AS in the AS_PATH, and can be launched
@@ -388,8 +388,8 @@
                 maxLength are actually announced by the AS in the ROA.
                 Another exception is where: (a) the maxLength is substantially larger compared to
                 the specified prefix length in the ROA, and (b) a large number of more specific
-                prefixes in that range are announced by the AS in the ROA. This case should occur
-                rarely in practice (if at all). Operator discretion is necessary in this case.
+                prefixes in that range are announced by the AS in the ROA. In practice, this case
+                should occur rarely (if at all). Operator discretion is necessary in this case.
             </t>
 
             <t>
@@ -404,8 +404,8 @@
                 Operators that have existing ROAs published in the RPKI system SHOULD perform a
                 review of such objects, especially where they make use of the maxLength attribute,
                 to ensure that the set of included prefixes is "minimal" with respect to the
-                current BGP origination and routing policies, and replace the published ROAs as
-                necessary.
+                current BGP origination and routing policies.
+                Published ROAs SHOULD be replaced as necessary.
                 Such an exercise SHOULD be repeated whenever the operator makes changes to either
                 policy.
             </t>
@@ -421,8 +421,8 @@
                 </t>
 
                 <t>
-                    In order to ensure that such ad hoc routing changes are effective, there should
-                    exist a ROA validating the new route. However a difficulty arises due to the
+                    In order to ensure that such ad hoc routing changes are effective, a ROA
+                    validating the new route should exist. However a difficulty arises due to the
                     fact that newly created objects in the RPKI are made visible to relying parties
                     considerably more slowly than routing updates in BGP.
                 </t>
@@ -474,7 +474,7 @@
                     When a DDoS attack is detected and reported by AS 64496, AS 64500 immediately
                     originates 192.168.0.0/22, thus attracting all the DDoS traffic to itself.
                     The traffic is scrubbed at AS 64500 and then sent back to AS 64496 over a
-                    backhaul data link.
+                    backhaul link.
                     Notice that, during a DDoS attack, the DDoS mitigation service provider AS
                     64500 originates a /22 prefix that is longer than AS 64496's /16 prefix, and so
                     all the traffic (destined to addresses in 192.168.0.0/22) that normally goes to
@@ -555,7 +555,7 @@
                     While it permits the DDoS mitigation service at AS 64500 to originate prefix
                     192.168.0.0/24 during a DDoS attack in that space, it also makes the other
                     /24 prefixes covered by the /22 prefix (i.e., 192.168.1.0/24, 192.168.2.0/24,
-                    192.168.3.0/24) vulnerable to a forged-origin sub-prefix attacks.
+                    192.168.3.0/24) vulnerable to forged-origin sub-prefix attacks.
                 </t>
             </section>
 
@@ -572,8 +572,8 @@
                     In some topologies, where at least one AS on every path between the victim
                     and hijacker filters ROV invalid prefixes, it may be the case that the
                     existence of a minimal ROA issued by the victim prevents the defensive
-                    more-specific prefixes being propagated to the networks topologically close to
-                    the attacker, thus hampering the effectiveness of this response.
+                    more-specific prefixes from being propagated to the networks topologically
+                    close to the attacker, thus hampering the effectiveness of this response.
                 </t>
                 <t>
                     Nevertheless, this document recommends that where possible, network operators
@@ -590,7 +590,7 @@
                         </t>
                         <t>
                             Other methods for reducing the size of such neighborhoods are available
-                            to potential victims, such as establishing direct eBGP adjacencies with
+                            to potential victims, such as establishing direct EBGP adjacencies with
                             networks from whom the defensive routes would otherwise be hidden.
                         </t>
                     </list>
@@ -639,7 +639,7 @@
 
     <section title="Operational Considerations" anchor="operational-considerations">
         <t>
-            The recommendations set out in this document, in particular, those in
+            The recommendations specified in this document, in particular, those in
             <xref target="recommendations"/>, involve trade-offs between operational agility and
             security.
         </t>
@@ -650,8 +650,8 @@
         </t>
         <t>
             Even in the case of routing changes that are planned in advance, existing procedures
-            may need to be updated to incorporate changes to issued ROAs, and additional time
-            allowed for those changes to propagate.
+            may need to be updated to incorporate changes to issued ROAs, and may require
+            additional time allowed for those changes to propagate.
         </t>
         <t>
             Operators are encouraged to carefully review the issues highlighted (especially those
@@ -665,7 +665,7 @@
         <t>
             This document makes recommendations regarding the use of RPKI-based origin validation
             as defined in <xref target="RFC6811"/>, and as such introduces no additional security
-            considerations beyond those set out therein.
+            considerations beyond those specified therein.
         </t>
     </section>
 
@@ -688,9 +688,10 @@
             and
             Amreesh Phokeer
             for comments and suggestions,
-            to Roni Even for Gen-ART review,
+            to Roni Even for the Gen-ART review,
+            to Jean Mahoney for the ART-ART review,
             and
-            to Jean Mahoney for ART-ART review.
+            to Acee Lindem for the Routing Directorate review.
         </t>
     </section>
 


### PR DESCRIPTION
resolves #29

- don't use '*' for emphasis
- hyphenate sub-prefix
- editorial recommendations from rtgdir review
- eliminate use of 'black hole' as far as possible

ping @job
